### PR TITLE
Sample implementation for shared state object pattern

### DIFF
--- a/src/SelectedPersonHolder.ts
+++ b/src/SelectedPersonHolder.ts
@@ -1,0 +1,5 @@
+import {Person} from './person';
+
+export class SelectedPersonHolder {
+  person: Person;
+}

--- a/src/app.html
+++ b/src/app.html
@@ -1,6 +1,7 @@
 <template>
     <require from="person-list"></require>
-  
+
+    selected: ${selectedPersonHolder.person.firstName} ${selectedPersonHolder.person.lastName}
     <div class="container">
         <person-list people.bind="people"></person-list>
     </div>

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,8 @@
-import {bindable} from 'aurelia-framework';
-
 import {Person} from './person';
 
 
 export class App {
-    @bindable() people: Person[] = [
+    people: Person[] = [
         {firstName: 'John', lastName: 'Doe'},
         {firstName: 'Joe', lastName: 'Bloggs'},
     ];

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,15 @@
 import {Person} from './person';
+import {SelectedPersonHolder} from './SelectedPersonHolder';
+import {autoinject} from 'aurelia-framework';
 
-
+@autoinject
 export class App {
     people: Person[] = [
         {firstName: 'John', lastName: 'Doe'},
         {firstName: 'Joe', lastName: 'Bloggs'},
     ];
+
+    constructor(private selectedPersonHolder: SelectedPersonHolder) {
+    }
+
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import {Person} from './person';
 import {SelectedPersonHolder} from './SelectedPersonHolder';
-import {autoinject} from 'aurelia-framework';
+import {autoinject, BindingEngine, Disposable} from 'aurelia-framework';
 
 @autoinject
 export class App {
@@ -8,8 +8,16 @@ export class App {
         {firstName: 'John', lastName: 'Doe'},
         {firstName: 'Joe', lastName: 'Bloggs'},
     ];
+    observerDisposer: Disposable;
 
-    constructor(private selectedPersonHolder: SelectedPersonHolder) {
+    constructor(private selectedPersonHolder: SelectedPersonHolder, private bindingEngine: BindingEngine) {
+      this.observerDisposer = this.bindingEngine.propertyObserver(this.selectedPersonHolder, "person")
+      .subscribe((person: Person, oldValue: Person) => {
+        alert(`${person.firstName} ${person.lastName} selected`);
+      });
     }
 
+    deactivate() {
+      this.observerDisposer.dispose();
+    }
 }

--- a/src/person-list.html
+++ b/src/person-list.html
@@ -2,7 +2,7 @@
     <ul class="list-group">
         <li class="list-group-item" repeat.for="person of people">
             ${person.firstName} ${person.lastName}
-            <button class="btn" click.trigger="selectPerson(person)">Select</button>
+            <button class="btn" click.delegate="selectPerson(person)">Select</button>
         </li>
     </ul>
 </template>

--- a/src/person-list.html
+++ b/src/person-list.html
@@ -2,7 +2,7 @@
     <ul class="list-group">
         <li class="list-group-item" repeat.for="person of people">
             ${person.firstName} ${person.lastName}
-            <button class="btn">Select</button>
+            <button class="btn" click.trigger="selectPerson(person)">Select</button>
         </li>
     </ul>
 </template>

--- a/src/person-list.ts
+++ b/src/person-list.ts
@@ -1,8 +1,16 @@
-import {bindable} from 'aurelia-framework';
+import {bindable, autoinject} from 'aurelia-framework';
 
 import {Person} from './person';
+import {SelectedPersonHolder} from './SelectedPersonHolder';
 
-
+@autoinject
 export class PersonList {
     @bindable() people: Person[];
+
+    constructor(private selectedPersonHolder: SelectedPersonHolder) {
+    }
+
+    selectPerson(person) {
+        this.selectedPersonHolder.person = person;
+    }
 }


### PR DESCRIPTION
Added sample implementation for shared state object pattern: #4 

Note: I created [separate commit for manually handling property changes](https://github.com/axwalker/aurelia-observer-patterns/commit/cbb6a0ebd44e7a63b933dce82ca92badad5e55a5) - without it this pattern is quite lightweight (in terms of [code overhead](https://github.com/axwalker/aurelia-observer-patterns/commit/aa1e038e631374568e9cb0036e7edc21716095de)) and easy to use in html templates.

**NB! Note that this PR shouldn't be merged to the master, but to new branch** - unfortunately i can't specify it with the PR
